### PR TITLE
fix: use new domain

### DIFF
--- a/src/listing/listing.service.ts
+++ b/src/listing/listing.service.ts
@@ -51,7 +51,7 @@ export class ListingService {
 
     return this.httpService
       .get<ClassifiedsSearchResponse>(
-        'https://backpack.tf/api/classifieds/listings/snapshot',
+        'https://backpacktf.trade/api/classifieds/listings/snapshot',
         {
           params: qs,
         },


### PR DESCRIPTION
backpack.tf is unavailable and new domain is backpacktf.trade